### PR TITLE
fix bug showing empty menu in case menubind.smn can't be found

### DIFF
--- a/setedit/setedit/menuload.cc
+++ b/setedit/setedit/menuload.cc
@@ -1315,7 +1315,6 @@ int LoadTVMenuAndStatus(char *fileName)
  char *s;
  DynStrCatStruct Cat;
  int PreproValue=1;
- InitAddSubMenu();
  TStatusDef *lastStatusDef=NULL;
 
  Error=0; Line=0;
@@ -1368,6 +1367,8 @@ int LoadTVMenuAndStatus(char *fileName)
  #if HAVE_CALENDAR
  defs->insert("CALENDAR");
  #endif
+
+ InitAddSubMenu();
 
  PreproInfo.depth=0;
  GetLine();


### PR DESCRIPTION
LoadTVMenuAndStatus() is called twice, first from GetTVStatusLine(), later from GetTVMenu(), but even if it fails early due to the inability to fopen(), InitAddSubmenu() is called which creates an empty 'firstMenu'.
GetTVMenu then skips creating the menu altogether, as it only does it if firstMenu isn't NULL.
firstMenu is then used as the menu, leaving it effectively blank, with no way of exiting the editor.